### PR TITLE
Add FastAPI backend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+# Python
+__pycache__/
+venv/
+.env

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Backend Server
+
+A simple FastAPI backend is included in `backend/main.py`. Install dependencies and run:
+
+```bash
+pip install -r backend/requirements.txt
+uvicorn backend.main:app --reload
+```
+
+The server exposes a `/ping` endpoint returning `{"message": "pong"}`.
+
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/ping")
+async def ping():
+    return {"message": "pong"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add simple FastAPI backend with ping endpoint
- document backend setup and ignore Python cache files

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68950bb1542c8331b0d869307ed68c01