### PR TITLE
Specify Node 18 for Render

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "engines": {
+    "node": "18.x"
+  },
   "eslintConfig": {
     "extends": [
       "react-app",


### PR DESCRIPTION
## Summary
- specify Node 18 in package engines to ensure Render uses correct runtime

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: Cannot find module '@testing-library/jest-dom')*


------
https://chatgpt.com/codex/tasks/task_e_6896033d1e0c8331b75c33547abf6555